### PR TITLE
Make test suite faster

### DIFF
--- a/tst/test.gi
+++ b/tst/test.gi
@@ -31,7 +31,11 @@ end;
 ## getRandomPerm(G) returns a permutation group that is a random isomorphism copy of G.
 getRandomPerm := function(G)
 	local H, gens, K;
-	    H := Image(IsomorphismPermGroup(G));
+	    if Size(G) <= 100 then
+	        H := Image(RegularActionHomomorphism(G));
+	    else
+	        H := Image(IsomorphismPermGroup(G));
+	    fi;
 	    repeat
 	       gens := List([1..Size(GeneratorsOfGroup(G))+3],x->Random(H));
 	       K := Group(gens);
@@ -39,25 +43,44 @@ getRandomPerm := function(G)
 	    return K;
 	end;
 
-## getRandomPerm(G) returns a PcGroup that is a random isomorphism copy of G.
+## getRandomPc(G) returns a PcGroup that is a random isomorphism copy of G.
 getRandomPc := function(G)
-	local pcgs,H,ns,N,el,hom,Q,i,rel,els;
+	local els, H, rel, p, B, epi, A, i, U, N, hom, el, pcgs;
 	   if not IsPcGroup(G) then G := Image(IsomorphismPcGroup(G)); fi;
 	   els  := [];
 	   H    := G;
 	   rel  := [];
 	   repeat
-	      ns  := Filtered(MaximalSubgroupClassReps(H),x-> IsNormal(H,x) and
-	              Size(x)<Size(H) and IsPrimeInt(Size(H)/Size(x)));
-	      N   := Random(ns);
+	      # locate a random normal subgroup of prime index. Such a subgroup
+	      # necessarily contains the derived subgroup; so we can just
+	      # as well look for a subgroup of prime index in the H/H'
+	      p   := Random(Set(Set(AbelianInvariants(H)),x->FactorsInt(x)[1]));
+	      N   := PRump(H, p);
+	      if Index(H,N) <> p then
+              epi := NaturalHomomorphismByNormalSubgroup(H, N);
+              A   := Image(epi);
+              i   := LogInt(Size(A), p);
+              # find a random subgroup of index p
+              U := Subgroup(A, List([1..i-1], x -> PseudoRandom(A)));
+              while Index(A,U) > p do
+                U := ClosureGroup(U, PseudoRandom(A));
+              od;
+              N := PreImages(epi, U);
+          fi;
+	      Assert(0, Index(H,N)=p);
 	      hom := NaturalHomomorphismByNormalSubgroup(H,N);
-	      el  := MinimalGeneratingSet(Image(hom))[1];
-	      el  := el^Random(Filtered([1..Order(el)],i-> Gcd(i,Order(el))=1));
-	      if not Order(el) mod Size(Image(hom))=0 then Error("mhmm"); fi;
+	      
+	      # The image of hom has prime order, so any non-trivial element
+	      # is a generator; we want a random one, so pick any, and then
+	      # power it up with a random number coprime to its order
+	      el  := First(GeneratorsOfGroup(Image(hom)), x->not IsOne(x));
+	      el  := el^Random(1, Order(el)-1);
+	      Assert(0, Size(Image(hom)) = p);
+	      Assert(0, Order(el) = Size(Image(hom)));
 	      Add(els,PreImagesRepresentative(hom,el));
 	      Add(rel,Size(Image(hom)));
 	      H   := N;
-	   until Size(H)=1;
+	   until IsTrivial(H);
 	   pcgs := PcgsByPcSequence(FamilyObj(els[1]),els);
 	   return GroupByPcgs(pcgs);
 	end;
@@ -66,7 +89,7 @@ getRandomPc := function(G)
 SOTRec.testSOTconst := function(n)
 	local all, g, id;
 		all := AllSOTGroups(n);
-		g := all[Random([1..NumberOfSOTGroups(n)])];
+		g := all[Random(1,NumberOfSOTGroups(n))];
 		id := IdSOTGroup(g);
 		if not IsIsomorphicSOTGroups(g, SOTGroup(id[1],id[2])) then Error("Revise p4q.");fi;
 	end;
@@ -74,7 +97,7 @@ SOTRec.testSOTconst := function(n)
 ## SOTRec.testIdSOTGroup(n) tests whether the same isomorphism type (given as random isomorphic copies of permutation groups) has the same SOT-group ID.
 ## test against SOT itself
 SOTRec.testIdSOTGroup := function(orders)
-    local n, nr, gap, sot, soty, i, copies,  gapid, new;
+    local n, nr, gap, sot, soty, i, copies,  gapid, new, signature;
     if IsInt(orders) then orders := [orders]; fi;
     for n in orders do
         if not IsSOTAvailable(n) then
@@ -86,19 +109,25 @@ SOTRec.testIdSOTGroup := function(orders)
 
         sot := List([1..nr],x->SOTGroup(n,x));
         soty := AllSOTGroups(n);
+        signature := SortedList(List(Collected(Factors(n)),x->x[2]));
         for i in [1..nr] do
             Assert(0, HasIdSOTGroup(sot[i]));
             Assert(0, HasIdSOTGroup(soty[i]));
             copies := [];
+            if IsPermGroup(sot[i]) then
+                Assert(0, sot[i] = soty[i]);
+            elif not signature in [ [1,4], [1,1,1,1] ] then # case p^4*q is problematic
+                Assert(0, CodePcGroup(sot[i]) = CodePcGroup(soty[i]));
+            elif CodePcGroup(sot[i]) <> CodePcGroup(soty[i]) then
+                Add(copies, getRandomPc(soty[i]));
+            fi;
             if n < 5000 then
                 Add(copies, getRandomPerm(sot[i]));
-                Add(copies, getRandomPerm(soty[i]));
                 if IsSolvableGroup(sot[i]) then
-                    Add(copies, getRandomPc(copies[2]));
+                    Add(copies, getRandomPc(sot[i]));
                 fi;
             else
                 Add(copies, getRandomPc(sot[i]));
-                Add(copies, getRandomPc(soty[i]));
             fi;
 
             if not ForAll(copies,x->IdSOTGroup(x)=[n,i]) then


### PR DESCRIPTION
We achieve this in multiple ways:
- for groups of order <= 100 use `RegularActionHomomorphism` instead of `IsomorphismPermGroup`, as it is much faster there and we don't care about the larger degree of the resulting permutation representations
- when we have to copies of the same group (`sot[i]` and `soty[i]`) don't bother to use `getRandomPc` on both if they use identical presentations
- rewrite `getRandomPc` to use a better algorithm that avoids computing all maximal subgroups (expensive) when all we want are normal subgroups of prime index

Before:

    125754 ms (19144 ms GC) and 44.8GB allocated

After:

    56931 ms (6719 ms GC) and 17.4GB allocated